### PR TITLE
Add package to protobuf definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,12 @@
 # rethinkdb-protobuf
 
-A Clojure library designed to ... well, that part is up to you.
+This Clojure library generates protocol buffers for use in Java or Clojure applications. The versions of this library correspond to the released versions of RethinkDB's protocol buffer. 
 
 ## Usage
 
-FIXME
+```
+lein protobuf
+```
 
 ## License
 

--- a/project.clj
+++ b/project.clj
@@ -1,5 +1,5 @@
-(defproject rethinkdb-protobuf "0.3.0"
-  :description "Protobufs for RethinkDB version 1.16.x"
+(defproject rethinkdb-protobuf "2.0.3"
+  :description "Protobufs for RethinkDB"
   :url "http://github.com/apa512/clj-rethinkdb"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}

--- a/project.clj
+++ b/project.clj
@@ -5,4 +5,4 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.6.0"]
                  [org.flatland/protobuf "0.8.1"]]
-  :plugins [[lein-protobuf "0.4.1"]])
+  :plugins [[lein-protobuf "0.4.3"]])

--- a/resources/proto/ql2.proto
+++ b/resources/proto/ql2.proto
@@ -39,6 +39,8 @@
 //   token to get more results from the original query.
 ////////////////////////////////////////////////////////////////////////////////
 
+package rethinkdb;
+
 message VersionDummy { // We need to wrap it like this for some
                        // non-conforming protobuf libraries
     // This enum contains the magic numbers for your version.  See **THE HIGH-LEVEL


### PR DESCRIPTION
Add the extra field `package` to the protobuf definition. This means that generated protocol buffers will have a proper Java package. Updates version to 2.0.3 to match the QL2.proto file used in that release of RethinkDB.

Fixes #1, Fixes #2
