### PR TITLE
Make Clojure and flatland/protobuf dev dependencies

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -3,6 +3,6 @@
   :url "http://github.com/apa512/clj-rethinkdb"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.6.0"]
-                 [org.flatland/protobuf "0.8.1"]]
+  :profiles {:dev {:dependencies [[org.clojure/clojure "1.6.0"]
+                                  [org.flatland/protobuf "0.8.1"]]}}
   :plugins [[lein-protobuf "0.4.3"]])


### PR DESCRIPTION
This means that people requiring this library won't need to have an unnecessary dependency on org.flatland/protobuf when the protobuf has already been generated.
